### PR TITLE
Change synth endpoint to be able to sort results

### DIFF
--- a/server/queries/allQueries.js
+++ b/server/queries/allQueries.js
@@ -1,4 +1,5 @@
 const {Synth, Manufacturer, Specification, User} = require('../models');
+const {Op} = require('sequelize');
 
 async function checkApiKey(key) {
   try {
@@ -46,7 +47,8 @@ async function manufacturerByName(name) {
 async function synthsAll(
   specificationQuery,
   manufacturerQuery,
-  pagination = {limit: 20, offset: 0}
+  pagination = {limit: 20, offset: 0},
+  sortByQuery
 ) {
   const synths = await Synth.findAndCountAll({
     ...pagination,
@@ -60,6 +62,7 @@ async function synthsAll(
         where: {...manufacturerQuery},
       },
     ],
+    order: [[Specification, sortByQuery.sortBy, sortByQuery.sortOrder]],
   });
   return synths;
 }

--- a/server/routers/api.js
+++ b/server/routers/api.js
@@ -100,6 +100,12 @@ apiRoutes.get(
       .shape({
         limit: yup.number().integer().min(1).default(20),
         offset: yup.number().integer().min(0).default(0),
+        sortBy: yup.string().oneOf(['yearProduced']),
+        sortOrder: yup
+          .string()
+          .uppercase()
+          .oneOf(['ASC', 'DESC'])
+          .default('ASC'),
         polyphony: yup.string(),
         keyboard: yup.string(),
         control: yup.string(),
@@ -120,11 +126,13 @@ apiRoutes.get(
         specificationQuery,
         manufacturerQuery,
         paginationQuery,
+        sortByQuery,
       } = formatSynthQuery(req.validatedQuery);
       const result = await synthsAll(
         specificationQuery,
         manufacturerQuery,
-        paginationQuery
+        paginationQuery,
+        sortByQuery
       );
       if (result.rows.length === 0) {
         res.status(404);

--- a/server/test/synths.test.js
+++ b/server/test/synths.test.js
@@ -153,5 +153,29 @@ describe('GET /', () => {
       expect(res.body.name).toBe(synth.name);
       done();
     });
+
+    test('should accept sortBy query with value of yearProduced', async (done) => {
+      const res = await server.get(
+        '/api/synths?limit=2&offset=0&sortBy=yearProduced&key=GVMVW12-1XK4W8E-HEND0CT-DVDB4DE'
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.synths[0].name).toBe('Roland JV-2080');
+      expect(res.body.synths[1].name).toBe('Sequential Circuits Prophet 3000');
+      done();
+    });
+
+    test('should accept sortBy and sortOrder query with value of yearProduced', async (done) => {
+      const res = await server.get(
+        '/api/synths?limit=2&offset=0&sortBy=yearProduced&sortOrder=DESC&key=GVMVW12-1XK4W8E-HEND0CT-DVDB4DE'
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.synths[0].name).toBe(
+        'Vermona Dual Analog Filter (DAF-1)'
+      );
+      expect(res.body.synths[res.body.synths.length - 1].name).toBe(
+        'TC|Works Mercury-1'
+      );
+      done();
+    });
   });
 });

--- a/server/validators/queryValidators.js
+++ b/server/validators/queryValidators.js
@@ -2,9 +2,12 @@ function formatSynthQuery(query) {
   let manufacturerQuery = {};
   let paginationQuery = {};
   let specificationQuery = {};
+  let sortByQuery = {};
 
+  // toevoegen
   let manufacturerOptions = ['manufacturer'];
   let paginationOptions = ['limit', 'offset'];
+  let sortByOptions = ['sortBy', 'sortOrder'];
   let specificationOptions = [
     'polyphony',
     'keyboard',
@@ -16,6 +19,12 @@ function formatSynthQuery(query) {
     'lfo',
     'effects',
   ];
+
+  for (const option of sortByOptions) {
+    if (query.hasOwnProperty(option)) {
+      sortByQuery[option] = query[option];
+    }
+  }
 
   for (const option of specificationOptions) {
     if (query.hasOwnProperty(option)) {
@@ -37,6 +46,7 @@ function formatSynthQuery(query) {
     specificationQuery: specificationQuery,
     manufacturerQuery: manufacturerQuery,
     paginationQuery: paginationQuery,
+    sortByQuery: sortByQuery,
   };
 }
 


### PR DESCRIPTION
What is in this PR:
- [ ] use query to sort results by yearProduced
- [ ] use query to change sorting option